### PR TITLE
Wrong tileset is referenced when using multiple tilesets

### DIFF
--- a/content/test-maps/project/maps/map3.json
+++ b/content/test-maps/project/maps/map3.json
@@ -54,7 +54,7 @@
  "nextobjectid":2,
  "orientation":"orthogonal",
  "renderorder":"left-down",
- "tiledversion":"1.4.1",
+ "tiledversion":"1.4.3",
  "tileheight":16,
  "tilesets":[
         {
@@ -81,6 +81,15 @@
          "spacing":0,
          "tilecount":48,
          "tileheight":16,
+         "tiles":[
+                {
+                 "animation":[
+                        {
+                         "duration":500,
+                         "tileid":1
+                        }],
+                 "id":1
+                }],
          "tilewidth":16
         }],
  "tilewidth":16,

--- a/examples/sfml/SfmlDemoManager.h
+++ b/examples/sfml/SfmlDemoManager.h
@@ -15,8 +15,8 @@
 #include "vera_font.h"
 
 #include "../../include/external/nlohmann.hpp"
-#include "../../include/tileson.h"
-//#include "../../single_include/tileson.hpp"
+//#include "../../include/tileson.h"
+#include "../../single_include/tileson.hpp"
 //#include "../../include/external/json.hpp"
 //#include "../../single_include/tileson_min.hpp"
 

--- a/include/common/tileson_forward.hpp
+++ b/include/common/tileson_forward.hpp
@@ -30,6 +30,21 @@ const tson::Vector2i tson::Tile::getTileSize() const
         return {0,0};
 }
 
+bool tson::Tile::parseId(IJson &json)
+{
+    if(json.count("id") > 0)
+    {
+        m_id = json["id"].get<uint32_t>() + 1;
+        if (m_tileset != nullptr)
+            m_gid = m_tileset->getFirstgid() + m_id - 1;
+        else
+            m_gid = m_id;
+        manageFlipFlagsByIdThenRemoveFlags(m_gid);
+        return true;
+    }
+    return false;
+}
+
 /*!
  * Uses tson::Tileset and tson::Map data to calculate related values for tson::Tile.
  * Added in v1.2.0

--- a/include/tiled/Map.hpp
+++ b/include/tiled/Map.hpp
@@ -219,7 +219,7 @@ void tson::Map::processData()
     m_tileMap.clear();
     for(auto &tileset : m_tilesets)
     {
-        std::for_each(tileset.getTiles().begin(), tileset.getTiles().end(), [&](tson::Tile &tile) { m_tileMap[tile.getId()] = &tile; });
+        std::for_each(tileset.getTiles().begin(), tileset.getTiles().end(), [&](tson::Tile &tile) { m_tileMap[tile.getGid()] = &tile; });
     }
     std::for_each(m_layers.begin(), m_layers.end(), [&](tson::Layer &layer)
     {

--- a/include/tiled/Tile.hpp
+++ b/include/tiled/Tile.hpp
@@ -25,7 +25,7 @@ namespace tson
             inline Tile(uint32_t id, tson::Tileset *tileset, tson::Map *map);
             inline Tile(uint32_t id, tson::Map *map); //v1.2.0
             inline bool parse(IJson &json, tson::Tileset *tileset, tson::Map *map);
-
+            inline bool parseId(IJson &json);
 
 
             [[nodiscard]] inline uint32_t getId() const;
@@ -144,18 +144,9 @@ bool tson::Tile::parse(IJson &json, tson::Tileset *tileset, tson::Map *map)
     m_tileset = tileset;
     m_map = map;
 
-    bool allFound = true;
-
     if(json.count("image") > 0) m_image = fs::path(json["image"].get<std::string>()); //Optional
 
-    if(json.count("id") > 0)
-    {
-        m_id = json["id"].get<uint32_t>() + 1;
-        m_gid = m_id;
-        manageFlipFlagsByIdThenRemoveFlags(m_gid);
-    }
-    else
-        allFound = false;
+    bool allFound = parseId(json);
 
     if(json.count("type") > 0) m_type = json["type"].get<std::string>(); //Optional
     if(json.count("objectgroup") > 0) m_objectgroup = tson::Layer(json["objectgroup"], m_map); //Optional

--- a/single_include/tileson_min.hpp
+++ b/single_include/tileson_min.hpp
@@ -4262,6 +4262,7 @@ namespace tson
 			inline Tile(uint32_t id, tson::Tileset *tileset, tson::Map *map);
 			inline Tile(uint32_t id, tson::Map *map); //v1.2.0
 			inline bool parse(IJson &json, tson::Tileset *tileset, tson::Map *map);
+			inline bool parseId(IJson &json);
 
 			[[nodiscard]] inline uint32_t getId() const;
 
@@ -4378,18 +4379,9 @@ bool tson::Tile::parse(IJson &json, tson::Tileset *tileset, tson::Map *map)
 	m_tileset = tileset;
 	m_map = map;
 
-	bool allFound = true;
-
 	if(json.count("image") > 0) m_image = fs::path(json["image"].get<std::string>()); //Optional
 
-	if(json.count("id") > 0)
-	{
-		m_id = json["id"].get<uint32_t>() + 1;
-		m_gid = m_id;
-		manageFlipFlagsByIdThenRemoveFlags(m_gid);
-	}
-	else
-		allFound = false;
+	bool allFound = parseId(json);
 
 	if(json.count("type") > 0) m_type = json["type"].get<std::string>(); //Optional
 	if(json.count("objectgroup") > 0) m_objectgroup = tson::Layer(json["objectgroup"], m_map); //Optional
@@ -5394,7 +5386,7 @@ void tson::Map::processData()
 	m_tileMap.clear();
 	for(auto &tileset : m_tilesets)
 	{
-		std::for_each(tileset.getTiles().begin(), tileset.getTiles().end(), [&](tson::Tile &tile) { m_tileMap[tile.getId()] = &tile; });
+		std::for_each(tileset.getTiles().begin(), tileset.getTiles().end(), [&](tson::Tile &tile) { m_tileMap[tile.getGid()] = &tile; });
 	}
 	std::for_each(m_layers.begin(), m_layers.end(), [&](tson::Layer &layer)
 	{
@@ -6251,6 +6243,21 @@ const tson::Vector2i tson::Tile::getTileSize() const
 		return m_map->getTileSize();
 	else
 		return {0,0};
+}
+
+bool tson::Tile::parseId(IJson &json)
+{
+	if(json.count("id") > 0)
+	{
+		m_id = json["id"].get<uint32_t>() + 1;
+		if (m_tileset != nullptr)
+			m_gid = m_tileset->getFirstgid() + m_id - 1;
+		else
+			m_gid = m_id;
+		manageFlipFlagsByIdThenRemoveFlags(m_gid);
+		return true;
+	}
+	return false;
 }
 
 /*!

--- a/tests/tests_main.cpp
+++ b/tests/tests_main.cpp
@@ -494,7 +494,9 @@ TEST_CASE( "Parse map3.json - expect correct tileset data for all TileObjects", 
                 }
             }
         }
-
+        tson::Layer *layer = map->getLayer("Main Layer");
+        tson::Tile *tile = layer->getTileData(3, 0);
+        REQUIRE(tile->getTileset()->getName() == "demo-tileset");
     }
     else
     {


### PR DESCRIPTION
Tiled uses the tileset-local tile id for animations rather than the tile gid.
This is a problem because tileset tile id's overlap when using multiple tilesets
with animations.

This PR adds a test for demonstrating the wrong tileset is chosen as well as a
fix for it.

This changes the tile gid to be globally unique based on the first gid of each tileset.
Map::processData is updated so the tilemap maps tile gid -> tile instead of tile id -> tile.
This allows the correct tile and tileset to be surfaced.