### PR TITLE
Added virtual destructors to pure virtual classes

### DIFF
--- a/include/interfaces/IDecompressor.hpp
+++ b/include/interfaces/IDecompressor.hpp
@@ -46,6 +46,11 @@ namespace tson
              * @return
              */
             virtual TOut decompress(const void *data, size_t size) = 0;
+
+            /*!
+			 * Pure virtual class needs virtual destructor so derrived classes can call their own destructors
+			*/
+			virtual ~IDecompressor() = default;
     };
 }
 

--- a/include/interfaces/IJson.hpp
+++ b/include/interfaces/IJson.hpp
@@ -47,6 +47,11 @@ namespace tson
             [[nodiscard]] virtual fs::path directory() const = 0;
             virtual void directory(const fs::path &directory) = 0;
 
+            /*!
+			 * Pure virtual class needs virtual destructor so derrived classes can call their own destructors
+			*/
+			virtual ~IJson() = default;
+
 
         protected:
             [[nodiscard]] virtual int32_t getInt32(std::string_view key) = 0;

--- a/tileson.hpp
+++ b/tileson.hpp
@@ -1225,6 +1225,11 @@ namespace tson
 			 * @return
 			 */
 			virtual TOut decompress(const void *data, size_t size) = 0;
+
+			/*!
+			 * Pure virtual class needs virtual destructor so derrived classes can call their own destructors
+			*/
+			virtual ~IDecompressor() = default;
 	};
 }
 
@@ -1863,6 +1868,11 @@ namespace tson
 			 */
 			[[nodiscard]] virtual fs::path directory() const = 0;
 			virtual void directory(const fs::path &directory) = 0;
+
+			/*!
+			 * Pure virtual class needs virtual destructor so derrived classes can call their own destructors
+			*/
+			virtual ~IJson() = default;
 
 		protected:
 			[[nodiscard]] virtual int32_t getInt32(std::string_view key) = 0;

--- a/tileson_min.hpp
+++ b/tileson_min.hpp
@@ -241,6 +241,11 @@ namespace tson
 			 * @return
 			 */
 			virtual TOut decompress(const void *data, size_t size) = 0;
+
+			/*!
+			 * Pure virtual class needs virtual destructor so derrived classes can call their own destructors
+			*/
+			virtual ~IDecompressor() = default;
 	};
 }
 
@@ -879,6 +884,11 @@ namespace tson
 			 */
 			[[nodiscard]] virtual fs::path directory() const = 0;
 			virtual void directory(const fs::path &directory) = 0;
+
+			/*!
+			 * Pure virtual class needs virtual destructor so derrived classes can call their own destructors
+			*/
+			virtual ~IJson() = default;
 
 		protected:
 			[[nodiscard]] virtual int32_t getInt32(std::string_view key) = 0;


### PR DESCRIPTION
If a class is going to be derrived later on, its destructor needs to be marked as virtual. Without this, there is the possibility of leaking memory as the overloaded destructor is not called.
The main point of this change however was to silence the 100 line warning clang++ was giving me about this on linux, and I thought that may as well be added to the main branch.