### PR TITLE
Fixed a problem causing Tileson unable to track changes in class values (#79)

### DIFF
--- a/content/test-maps/project-v1.9/maps/map1.json
+++ b/content/test-maps/project-v1.9/maps/map1.json
@@ -26,6 +26,12 @@
          "id":1,
          "name":"Main Layer",
          "opacity":1,
+         "properties":[
+                {
+                 "name":"isDummy",
+                 "type":"bool",
+                 "value":true
+                }],
          "type":"tilelayer",
          "visible":true,
          "width":32,
@@ -47,6 +53,28 @@
                         {
                          "name":"hp",
                          "type":"int",
+                         "value":10
+                        }, 
+                        {
+                         "name":"name",
+                         "type":"string",
+                         "value":"Galderino"
+                        }],
+                 "rotation":0,
+                 "visible":true,
+                 "width":64,
+                 "x":238.995438269485,
+                 "y":29.9908765389709
+                }, 
+                {
+                 "class":"Enemy",
+                 "height":64,
+                 "id":3,
+                 "name":"TestObject2",
+                 "properties":[
+                        {
+                         "name":"hp",
+                         "type":"int",
                          "value":1
                         }, 
                         {
@@ -57,10 +85,16 @@
                  "rotation":0,
                  "visible":true,
                  "width":64,
-                 "x":240,
-                 "y":32
+                 "x":327.633099524207,
+                 "y":24.2554569088144
                 }],
          "opacity":1,
+         "properties":[
+                {
+                 "name":"isDummy",
+                 "type":"bool",
+                 "value":true
+                }],
          "type":"objectgroup",
          "visible":true,
          "x":0,
@@ -72,13 +106,19 @@
          "image":"",
          "name":"Da Image Layer",
          "opacity":1,
+         "properties":[
+                {
+                 "name":"isDummy",
+                 "type":"bool",
+                 "value":true
+                }],
          "type":"imagelayer",
          "visible":true,
          "x":0,
          "y":0
         }],
  "nextlayerid":4,
- "nextobjectid":3,
+ "nextobjectid":4,
  "orientation":"orthogonal",
  "properties":[
         {
@@ -123,6 +163,11 @@
          "value":45.699
         }, 
         {
+         "name":"isDummy",
+         "type":"bool",
+         "value":true
+        }, 
+        {
          "name":"number",
          "type":"int",
          "value":42
@@ -140,13 +185,25 @@
          "imagewidth":128,
          "margin":0,
          "name":"demo-tileset",
+         "properties":[
+                {
+                 "name":"isDummy",
+                 "type":"bool",
+                 "value":true
+                }],
          "spacing":0,
          "tilecount":48,
          "tileheight":16,
          "tiles":[
                 {
                  "class":"DummyClass",
-                 "id":0
+                 "id":0,
+                 "properties":[
+                        {
+                         "name":"isDummy",
+                         "type":"bool",
+                         "value":true
+                        }]
                 }],
          "tilewidth":16,
          "wangsets":[
@@ -158,9 +215,21 @@
                          "color":"#ff0000",
                          "name":"Britt",
                          "probability":1,
+                         "properties":[
+                                {
+                                 "name":"isDummy",
+                                 "type":"bool",
+                                 "value":true
+                                }],
                          "tile":-1
                         }],
                  "name":"wang-1",
+                 "properties":[
+                        {
+                         "name":"isDummy",
+                         "type":"bool",
+                         "value":true
+                        }],
                  "tile":-1,
                  "type":"corner",
                  "wangtiles":[]

--- a/content/test-maps/project-v1.9/test.tiled-project
+++ b/content/test-maps/project-v1.9/test.tiled-project
@@ -32,7 +32,7 @@
                 {
                     "name": "isDummy",
                     "type": "bool",
-                    "value": true
+                    "value": false
                 }
             ],
             "name": "DummyClass",

--- a/include/common/tileson_forward.hpp
+++ b/include/common/tileson_forward.hpp
@@ -19,7 +19,16 @@
 
 tson::TiledClass *tson::Map::getClass()
 {
-    return (m_project != nullptr) ? m_project->getClass(m_classType) : nullptr;
+    if(m_class == nullptr)
+    {
+        TiledClass* baseClass = (m_project != nullptr) ? m_project->getClass(m_classType) : nullptr;
+        if(baseClass != nullptr)
+        {
+            m_class = std::make_shared<TiledClass>(*baseClass);
+            m_class->update(m_properties);
+        }
+    }
+    return (m_class != nullptr) ? m_class.get() : nullptr;
 }
 
 // T i l e . h p p
@@ -99,7 +108,16 @@ const tson::Vector2f tson::Tile::getPosition(const std::tuple<int, int> &tileDat
  */
 tson::TiledClass *tson::Tile::getClass()
 {
-    return (m_map != nullptr && m_map->getProject() != nullptr) ? m_map->getProject()->getClass(m_type) : nullptr;
+    if(m_class == nullptr)
+    {
+        TiledClass* baseClass = (m_map != nullptr && m_map->getProject() != nullptr) ? m_map->getProject()->getClass(m_type) : nullptr;
+        if(baseClass != nullptr)
+        {
+            m_class = std::make_shared<TiledClass>(*baseClass);
+            m_class->update(m_properties);
+        }
+    }
+    return (m_class != nullptr) ? m_class.get() : nullptr;
 }
 
 // T i l e s e t . h p p
@@ -107,7 +125,16 @@ tson::TiledClass *tson::Tile::getClass()
 
 tson::TiledClass *tson::Tileset::getClass()
 {
-    return (m_map != nullptr && m_map->getProject() != nullptr) ? m_map->getProject()->getClass(m_classType) : nullptr;
+    if(m_class == nullptr)
+    {
+        TiledClass* baseClass = (m_map != nullptr && m_map->getProject() != nullptr) ? m_map->getProject()->getClass(m_classType) : nullptr;
+        if(baseClass != nullptr)
+        {
+            m_class = std::make_shared<TiledClass>(*baseClass);
+            m_class->update(m_properties);
+        }
+    }
+    return (m_class != nullptr) ? m_class.get() : nullptr;
 }
 
 // T i l e O b j e c t . h p p
@@ -251,7 +278,16 @@ bool tson::Layer::parse(IJson &json, tson::Map *map)
 
 tson::TiledClass *tson::Layer::getClass()
 {
-    return (m_map != nullptr && m_map->getProject() != nullptr) ? m_map->getProject()->getClass(m_classType) : nullptr;
+    if(m_class == nullptr)
+    {
+        TiledClass* baseClass = (m_map != nullptr && m_map->getProject() != nullptr) ? m_map->getProject()->getClass(m_classType) : nullptr;
+        if(baseClass != nullptr)
+        {
+            m_class = std::make_shared<TiledClass>(*baseClass);
+            m_class->update(m_properties);
+        }
+    }
+    return (m_class != nullptr) ? m_class.get() : nullptr;
 }
 
 // O b j e c t . h p p
@@ -261,14 +297,32 @@ tson::TiledClass *tson::Layer::getClass()
 // ----------------------
 tson::TiledClass *tson::WangSet::getClass()
 {
-    return (m_map != nullptr && m_map->getProject() != nullptr) ? m_map->getProject()->getClass(m_classType) : nullptr;
+    if(m_class == nullptr)
+    {
+        TiledClass* baseClass = (m_map != nullptr && m_map->getProject() != nullptr) ? m_map->getProject()->getClass(m_classType) : nullptr;
+        if(baseClass != nullptr)
+        {
+            m_class = std::make_shared<TiledClass>(*baseClass);
+            m_class->update(m_properties);
+        }
+    }
+    return (m_class != nullptr) ? m_class.get() : nullptr;
 }
 
 // W a n g c o l o r . h p p
 // ----------------------
 tson::TiledClass *tson::WangColor::getClass()
 {
-    return (m_map != nullptr && m_map->getProject() != nullptr) ? m_map->getProject()->getClass(m_classType) : nullptr;
+    if(m_class == nullptr)
+    {
+        TiledClass* baseClass = (m_map != nullptr && m_map->getProject() != nullptr) ? m_map->getProject()->getClass(m_classType) : nullptr;
+        if(baseClass != nullptr)
+        {
+            m_class = std::make_shared<TiledClass>(*baseClass);
+            m_class->update(m_properties);
+        }
+    }
+    return (m_class != nullptr) ? m_class.get() : nullptr;
 }
 
 /*!
@@ -278,7 +332,16 @@ tson::TiledClass *tson::WangColor::getClass()
  */
 tson::TiledClass *tson::Object::getClass()
 {
-    return (m_map != nullptr && m_map->getProject() != nullptr) ? m_map->getProject()->getClass(m_type) : nullptr;
+    if(m_class == nullptr)
+    {
+        TiledClass* baseClass = (m_map != nullptr && m_map->getProject() != nullptr) ? m_map->getProject()->getClass(m_type) : nullptr;
+        if(baseClass != nullptr)
+        {
+            m_class = std::make_shared<TiledClass>(*baseClass);
+            m_class->update(m_properties);
+        }
+    }
+    return (m_class != nullptr) ? m_class.get() : nullptr;
 }
 
 // W o r l d . h p p

--- a/include/objects/PropertyCollection.hpp
+++ b/include/objects/PropertyCollection.hpp
@@ -25,6 +25,7 @@ namespace tson
             inline void remove(const std::string &name);
 
             inline void setValue(const std::string &name, const std::any &value);
+            inline void setProperty(const std::string &name, const tson::Property &value);
             inline void setId(const std::string &id);
 
             inline bool hasProperty(const std::string &name);
@@ -89,6 +90,16 @@ void tson::PropertyCollection::setValue(const std::string &name, const std::any 
 {
     if(m_properties.count(name) > 0)
         m_properties[name].setValue(value);
+}
+
+/*!
+ * Overwrites the current property if it exists, or adds it if it doesn't.
+ * @param name
+ * @param value
+ */
+void tson::PropertyCollection::setProperty(const std::string &name, const tson::Property &value)
+{
+    m_properties[name] = value;
 }
 
 void tson::PropertyCollection::setId(const std::string &id)

--- a/include/tiled/Layer.hpp
+++ b/include/tiled/Layer.hpp
@@ -131,7 +131,7 @@ namespace tson
             std::vector<tson::FlaggedTile>                      m_flaggedTiles;
 
             std::string                                         m_classType{};              /*! 'class': The class of this map (since 1.9, defaults to “”). */
-
+            std::shared_ptr<tson::TiledClass>                   m_class {};
     };
 
     /*!

--- a/include/tiled/Map.hpp
+++ b/include/tiled/Map.hpp
@@ -106,6 +106,7 @@ namespace tson
             std::map<uint32_t, tson::Tile>         m_flaggedTileMap{};    /*! key: Tile ID. Value: Tile*/
 
             std::string                            m_classType{};              /*! 'class': The class of this map (since 1.9, defaults to “”). */
+            std::shared_ptr<tson::TiledClass>      m_class {};
     };
 
     /*!

--- a/include/tiled/Object.hpp
+++ b/include/tiled/Object.hpp
@@ -11,6 +11,7 @@
 #include "Text.hpp"
 
 #include "../common/Enums.hpp"
+#include <optional>
 
 namespace tson
 {
@@ -90,6 +91,7 @@ namespace tson
             tson::TileFlipFlags               m_flipFlags = TileFlipFlags::None;       /*! Resolved using bit 32, 31 and 30 from gid */
 
             tson::Map *m_map {nullptr};
+            std::shared_ptr<tson::TiledClass> m_class {};
     };
 
     /*!

--- a/include/tiled/Tile.hpp
+++ b/include/tiled/Tile.hpp
@@ -87,6 +87,7 @@ namespace tson
             inline void performDataCalculations();                                   /*! Declared in tileson_forward.hpp - Calculate all the values used in the tile class. */
             inline void manageFlipFlagsByIdThenRemoveFlags(uint32_t &id);
             friend class Layer;
+            std::shared_ptr<tson::TiledClass> m_class {};
     };
 
     /*!

--- a/include/tiled/TiledClass.hpp
+++ b/include/tiled/TiledClass.hpp
@@ -7,7 +7,6 @@
 
 namespace tson
 {
-    //class Project;
     class TiledClass
     {
         public:
@@ -19,6 +18,7 @@ namespace tson
             [[nodiscard]] inline const std::string &getType() const;
             [[nodiscard]] inline const PropertyCollection &getMembers() const;
             inline void update(IJson &json);
+            inline void update(PropertyCollection &properties);
 
             template <typename T>
             inline T get(const std::string &name);
@@ -91,13 +91,34 @@ namespace tson
      */
     void TiledClass::update(IJson &json)
     {
-        for(auto property : m_members.get())
+        for(Property *property : m_members.get())
         {
             if(json.any(property->getName()))
             {
                 property->setValueByType(json[property->getName()]);
             }
         }
+    }
+
+    void TiledClass::update(PropertyCollection &properties)
+    {
+        std::vector<Property *> toUpdate;
+        for(Property *member : m_members.get())
+        {
+            if(properties.hasProperty(member->getName()))
+            {
+                Property *property = properties.getProperty(member->getName());
+                if(member->getType() == property->getType())
+                {
+                    toUpdate.push_back(property);
+                }
+            }
+        }
+
+        std::for_each(toUpdate.begin(), toUpdate.end(), [&](Property *p)
+        {
+           m_members.setProperty(p->getName(), *p);
+        });
     }
 }
 

--- a/include/tiled/Tileset.hpp
+++ b/include/tiled/Tileset.hpp
@@ -115,7 +115,7 @@ namespace tson
  *                                                                    Only relevant when the tiles are not rendered at their native size, so this applies to resized tile objects or in combination with 'tilerendersize' set to 'grid'. (since 1.9)*/
 
             std::string                   m_classType {};              /*! 'class': The class of this map (since 1.9, defaults to “”). */
-
+            std::shared_ptr<tson::TiledClass> m_class {};
     };
 
     /*!

--- a/include/tiled/WangColor.hpp
+++ b/include/tiled/WangColor.hpp
@@ -41,6 +41,7 @@ namespace tson
             tson::PropertyCollection     m_properties; 	  /*! 'properties': A list of properties (name, value, type). */
             tson::Map *                  m_map;
             std::string                  m_classType {};              /*! 'class': The class of this map (since 1.9, defaults to “”). */
+            std::shared_ptr<tson::TiledClass> m_class {};
 
     };
 }

--- a/include/tiled/WangSet.hpp
+++ b/include/tiled/WangSet.hpp
@@ -53,7 +53,7 @@ namespace tson
 
             tson::Map *                  m_map;
             std::string                  m_classType {};              /*! 'class': The class of this map (since 1.9, defaults to “”). */
-
+            std::shared_ptr<tson::TiledClass> m_class {};
 
     };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,9 @@ project(tileson_tests)
 
 set(CMAKE_CXX_STANDARD 17)
 
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DTILESON_UNIT_TEST_USE_SINGLE_HEADER")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTILESON_UNIT_TEST_USE_SINGLE_HEADER")
+
 # Uses the single header file when defined - comment out when creating PR: The cmake version in github doesn't seem to support it.
 # add_compile_definitions(TILESON_UNIT_TEST_USE_SINGLE_HEADER)
 

--- a/tests/tests_main.cpp
+++ b/tests/tests_main.cpp
@@ -7,8 +7,6 @@
 
 #include "../TilesonConfig.h"
 
-//#define TILESON_UNIT_TEST_USE_SINGLE_HEADER
-
 #include "../include/external/nlohmann.hpp"
 #include "../include/external/picojson.hpp"
 

--- a/tests/tests_projects_and_worlds.cpp
+++ b/tests/tests_projects_and_worlds.cpp
@@ -9,9 +9,9 @@
     #include "../tileson.hpp"
 #else
     #include "../include/tileson.h"
-#include "TestTools.hpp"
-
 #endif
+
+#include "TestTools.hpp"
 
 TEST_CASE( "Parse world - Expect 4 maps and parsed data", "[project][world]" )
 {
@@ -134,12 +134,7 @@ TEST_CASE( "Parse project with class and enum info in maps - expect right values
         }
     }
 }
-static void assertDummy(tson::TiledClass *c)
-{
-    REQUIRE(c != nullptr);
-    REQUIRE(c->getName() == "DummyClass");
-    REQUIRE(c->get<bool>("isDummy"));
-}
+
 
 TEST_CASE( "Parse Tiled v1.9 project with class and enum info in maps - expect right values", "[project][map]" )
 {
@@ -189,20 +184,44 @@ TEST_CASE( "Parse Tiled v1.9 project with class and enum info in maps - expect r
             tson::TiledClass *c7 = wangset->getClass();
             tson::TiledClass *c8 = wangcolor->getClass();
 
-            assertDummy(c1);
-            assertDummy(c2);
-            assertDummy(c3);
-            assertDummy(c4);
-            assertDummy(c5);
-            assertDummy(c6);
-            assertDummy(c7);
-            assertDummy(c8);
+            REQUIRE(c1 != nullptr);
+            REQUIRE(c1->getName() == "DummyClass");
+            REQUIRE(c1->get<bool>("isDummy"));
+            REQUIRE(c2 != nullptr);
+            REQUIRE(c2->getName() == "DummyClass");
+            REQUIRE(c2->get<bool>("isDummy"));
+            REQUIRE(c3 != nullptr);
+            REQUIRE(c3->getName() == "DummyClass");
+            REQUIRE(c3->get<bool>("isDummy"));
+            REQUIRE(c4 != nullptr);
+            REQUIRE(c4->getName() == "DummyClass");
+            REQUIRE(c4->get<bool>("isDummy"));
+            REQUIRE(c5 != nullptr);
+            REQUIRE(c5->getName() == "DummyClass");
+            REQUIRE(c5->get<bool>("isDummy"));
+            REQUIRE(c6 != nullptr);
+            REQUIRE(c6->getName() == "DummyClass");
+            REQUIRE(c6->get<bool>("isDummy"));
+            REQUIRE(c7 != nullptr);
+            REQUIRE(c7->getName() == "DummyClass");
+            REQUIRE(c7->get<bool>("isDummy"));
+            REQUIRE(c8 != nullptr);
+            REQUIRE(c8->getName() == "DummyClass");
+            REQUIRE(c8->get<bool>("isDummy"));
 
-            tson::TiledClass *objectClass = objectLayer->getObj(1)->getClass();
+            tson::TiledClass *objectClass = objectLayer->firstObj("TestObject")->getClass(); //Object is changed from default values
 
             REQUIRE(objectClass != nullptr);
             REQUIRE(objectClass->getName() == "Enemy");
-            REQUIRE(objectClass->get<int>("hp") == 1);
+            REQUIRE(objectClass->get<int>("hp") == 10);
+            REQUIRE(objectClass->get<std::string>("name") == "Galderino");
+
+            tson::TiledClass *objectClass2 = objectLayer->firstObj("TestObject2")->getClass(); //Object is unchanged
+            REQUIRE(objectClass2 != nullptr);
+            REQUIRE(objectClass2->getName() == "Enemy");
+            REQUIRE(objectClass2->get<int>("hp") == 1);
+            REQUIRE(objectClass2->get<std::string>("name").empty());
+
         }
     }
 }

--- a/tileson_min.hpp
+++ b/tileson_min.hpp
@@ -2566,6 +2566,7 @@ namespace tson
 			inline void remove(const std::string &name);
 
 			inline void setValue(const std::string &name, const std::any &value);
+			inline void setProperty(const std::string &name, const tson::Property &value);
 			inline void setId(const std::string &id);
 
 			inline bool hasProperty(const std::string &name);
@@ -2630,6 +2631,16 @@ void tson::PropertyCollection::setValue(const std::string &name, const std::any 
 {
 	if(m_properties.count(name) > 0)
 		m_properties[name].setValue(value);
+}
+
+/*!
+ * Overwrites the current property if it exists, or adds it if it doesn't.
+ * @param name
+ * @param value
+ */
+void tson::PropertyCollection::setProperty(const std::string &name, const tson::Property &value)
+{
+	m_properties[name] = value;
 }
 
 void tson::PropertyCollection::setId(const std::string &id)
@@ -2757,6 +2768,8 @@ namespace tson
 
 /*** End of inlined file: Text.hpp ***/
 
+#include <optional>
+
 namespace tson
 {
 	class TiledClass;
@@ -2833,6 +2846,7 @@ namespace tson
 			tson::TileFlipFlags               m_flipFlags = TileFlipFlags::None;       /*! Resolved using bit 32, 31 and 30 from gid */
 
 			tson::Map *m_map {nullptr};
+			std::shared_ptr<tson::TiledClass> m_class {};
 	};
 
 	/*!
@@ -3436,7 +3450,7 @@ namespace tson
 			std::vector<tson::FlaggedTile>                      m_flaggedTiles;
 
 			std::string                                         m_classType{};              /*! 'class': The class of this map (since 1.9, defaults to “”). */
-
+			std::shared_ptr<tson::TiledClass>                   m_class {};
 	};
 
 	/*!
@@ -4058,6 +4072,7 @@ namespace tson
 			tson::PropertyCollection     m_properties; 	  /*! 'properties': A list of properties (name, value, type). */
 			tson::Map *                  m_map;
 			std::string                  m_classType {};              /*! 'class': The class of this map (since 1.9, defaults to “”). */
+			std::shared_ptr<tson::TiledClass> m_class {};
 
 	};
 }
@@ -4330,6 +4345,7 @@ namespace tson
 
 			tson::Map *                  m_map;
 			std::string                  m_classType {};              /*! 'class': The class of this map (since 1.9, defaults to “”). */
+			std::shared_ptr<tson::TiledClass> m_class {};
 
 	};
 
@@ -4812,6 +4828,7 @@ namespace tson
 			inline void performDataCalculations();                                   /*! Declared in tileson_forward.hpp - Calculate all the values used in the tile class. */
 			inline void manageFlipFlagsByIdThenRemoveFlags(uint32_t &id);
 			friend class Layer;
+			std::shared_ptr<tson::TiledClass> m_class {};
 	};
 
 	/*!
@@ -5402,7 +5419,7 @@ namespace tson
  *                                                                    Only relevant when the tiles are not rendered at their native size, so this applies to resized tile objects or in combination with 'tilerendersize' set to 'grid'. (since 1.9)*/
 
 			std::string                   m_classType {};              /*! 'class': The class of this map (since 1.9, defaults to “”). */
-
+			std::shared_ptr<tson::TiledClass> m_class {};
 	};
 
 	/*!
@@ -5917,6 +5934,7 @@ namespace tson
 			std::map<uint32_t, tson::Tile>         m_flaggedTileMap{};    /*! key: Tile ID. Value: Tile*/
 
 			std::string                            m_classType{};              /*! 'class': The class of this map (since 1.9, defaults to “”). */
+			std::shared_ptr<tson::TiledClass>      m_class {};
 	};
 
 	/*!
@@ -6678,7 +6696,6 @@ namespace tson
 
 namespace tson
 {
-	//class Project;
 	class TiledClass
 	{
 		public:
@@ -6690,6 +6707,7 @@ namespace tson
 			[[nodiscard]] inline const std::string &getType() const;
 			[[nodiscard]] inline const PropertyCollection &getMembers() const;
 			inline void update(IJson &json);
+			inline void update(PropertyCollection &properties);
 
 			template <typename T>
 			inline T get(const std::string &name);
@@ -6762,13 +6780,34 @@ namespace tson
 	 */
 	void TiledClass::update(IJson &json)
 	{
-		for(auto property : m_members.get())
+		for(Property *property : m_members.get())
 		{
 			if(json.any(property->getName()))
 			{
 				property->setValueByType(json[property->getName()]);
 			}
 		}
+	}
+
+	void TiledClass::update(PropertyCollection &properties)
+	{
+		std::vector<Property *> toUpdate;
+		for(Property *member : m_members.get())
+		{
+			if(properties.hasProperty(member->getName()))
+			{
+				Property *property = properties.getProperty(member->getName());
+				if(member->getType() == property->getType())
+				{
+					toUpdate.push_back(property);
+				}
+			}
+		}
+
+		std::for_each(toUpdate.begin(), toUpdate.end(), [&](Property *p)
+		{
+		   m_members.setProperty(p->getName(), *p);
+		});
 	}
 }
 
@@ -7533,7 +7572,16 @@ tson::DecompressorContainer *tson::Tileson::decompressors()
 
 tson::TiledClass *tson::Map::getClass()
 {
-	return (m_project != nullptr) ? m_project->getClass(m_classType) : nullptr;
+	if(m_class == nullptr)
+	{
+		TiledClass* baseClass = (m_project != nullptr) ? m_project->getClass(m_classType) : nullptr;
+		if(baseClass != nullptr)
+		{
+			m_class = std::make_shared<TiledClass>(*baseClass);
+			m_class->update(m_properties);
+		}
+	}
+	return (m_class != nullptr) ? m_class.get() : nullptr;
 }
 
 // T i l e . h p p
@@ -7613,7 +7661,16 @@ const tson::Vector2f tson::Tile::getPosition(const std::tuple<int, int> &tileDat
  */
 tson::TiledClass *tson::Tile::getClass()
 {
-	return (m_map != nullptr && m_map->getProject() != nullptr) ? m_map->getProject()->getClass(m_type) : nullptr;
+	if(m_class == nullptr)
+	{
+		TiledClass* baseClass = (m_map != nullptr && m_map->getProject() != nullptr) ? m_map->getProject()->getClass(m_type) : nullptr;
+		if(baseClass != nullptr)
+		{
+			m_class = std::make_shared<TiledClass>(*baseClass);
+			m_class->update(m_properties);
+		}
+	}
+	return (m_class != nullptr) ? m_class.get() : nullptr;
 }
 
 // T i l e s e t . h p p
@@ -7621,7 +7678,16 @@ tson::TiledClass *tson::Tile::getClass()
 
 tson::TiledClass *tson::Tileset::getClass()
 {
-	return (m_map != nullptr && m_map->getProject() != nullptr) ? m_map->getProject()->getClass(m_classType) : nullptr;
+	if(m_class == nullptr)
+	{
+		TiledClass* baseClass = (m_map != nullptr && m_map->getProject() != nullptr) ? m_map->getProject()->getClass(m_classType) : nullptr;
+		if(baseClass != nullptr)
+		{
+			m_class = std::make_shared<TiledClass>(*baseClass);
+			m_class->update(m_properties);
+		}
+	}
+	return (m_class != nullptr) ? m_class.get() : nullptr;
 }
 
 // T i l e O b j e c t . h p p
@@ -7765,7 +7831,16 @@ bool tson::Layer::parse(IJson &json, tson::Map *map)
 
 tson::TiledClass *tson::Layer::getClass()
 {
-	return (m_map != nullptr && m_map->getProject() != nullptr) ? m_map->getProject()->getClass(m_classType) : nullptr;
+	if(m_class == nullptr)
+	{
+		TiledClass* baseClass = (m_map != nullptr && m_map->getProject() != nullptr) ? m_map->getProject()->getClass(m_classType) : nullptr;
+		if(baseClass != nullptr)
+		{
+			m_class = std::make_shared<TiledClass>(*baseClass);
+			m_class->update(m_properties);
+		}
+	}
+	return (m_class != nullptr) ? m_class.get() : nullptr;
 }
 
 // O b j e c t . h p p
@@ -7775,14 +7850,32 @@ tson::TiledClass *tson::Layer::getClass()
 // ----------------------
 tson::TiledClass *tson::WangSet::getClass()
 {
-	return (m_map != nullptr && m_map->getProject() != nullptr) ? m_map->getProject()->getClass(m_classType) : nullptr;
+	if(m_class == nullptr)
+	{
+		TiledClass* baseClass = (m_map != nullptr && m_map->getProject() != nullptr) ? m_map->getProject()->getClass(m_classType) : nullptr;
+		if(baseClass != nullptr)
+		{
+			m_class = std::make_shared<TiledClass>(*baseClass);
+			m_class->update(m_properties);
+		}
+	}
+	return (m_class != nullptr) ? m_class.get() : nullptr;
 }
 
 // W a n g c o l o r . h p p
 // ----------------------
 tson::TiledClass *tson::WangColor::getClass()
 {
-	return (m_map != nullptr && m_map->getProject() != nullptr) ? m_map->getProject()->getClass(m_classType) : nullptr;
+	if(m_class == nullptr)
+	{
+		TiledClass* baseClass = (m_map != nullptr && m_map->getProject() != nullptr) ? m_map->getProject()->getClass(m_classType) : nullptr;
+		if(baseClass != nullptr)
+		{
+			m_class = std::make_shared<TiledClass>(*baseClass);
+			m_class->update(m_properties);
+		}
+	}
+	return (m_class != nullptr) ? m_class.get() : nullptr;
 }
 
 /*!
@@ -7792,7 +7885,16 @@ tson::TiledClass *tson::WangColor::getClass()
  */
 tson::TiledClass *tson::Object::getClass()
 {
-	return (m_map != nullptr && m_map->getProject() != nullptr) ? m_map->getProject()->getClass(m_type) : nullptr;
+	if(m_class == nullptr)
+	{
+		TiledClass* baseClass = (m_map != nullptr && m_map->getProject() != nullptr) ? m_map->getProject()->getClass(m_type) : nullptr;
+		if(baseClass != nullptr)
+		{
+			m_class = std::make_shared<TiledClass>(*baseClass);
+			m_class->update(m_properties);
+		}
+	}
+	return (m_class != nullptr) ? m_class.get() : nullptr;
 }
 
 // W o r l d . h p p


### PR DESCRIPTION
- Closes #79

## Features
- The preprocessor `TILESON_UNIT_TEST_USE_SINGLE_HEADER` is now set by a `CMake`-flag in the `CMakeLists.txt` file related to `tests`, and is active by default.
- `project-v1.9/test.tiled-project`: Se t default value of `DummyClass` to false to track if any of the types inheriting from it actually gets a changed value.
- Changed properties in `map1.json` related to the same project to be able to make better tests.
- `tson::Layer`, `tson::Map`, `tson::Object`, `tson::Tile`, `tson::Tileset`, `tson::WangColor`, `tson::WangSet` now holds their own version of `tson::TiledClass` with their potential modified values, which is created the first time the `getClass()` function is called.