### PR TITLE
Use tileset tile size instead of map tile size for reporting tile size

### DIFF
--- a/content/test-maps/project-v1.10/maps/map1.json
+++ b/content/test-maps/project-v1.10/maps/map1.json
@@ -38,13 +38,13 @@
  "orientation":"orthogonal",
  "renderorder":"right-down",
  "tiledversion":"1.10.2",
- "tileheight":16,
+ "tileheight":32,
  "tilesets":[
         {
          "firstgid":1,
          "source":"..\/tilesets\/tileset1.json"
         }],
- "tilewidth":16,
+ "tilewidth":32,
  "type":"map",
  "version":"1.10",
  "width":30

--- a/include/common/tileson_forward.hpp
+++ b/include/common/tileson_forward.hpp
@@ -143,7 +143,7 @@ void tson::Tile::performDataCalculations()
         int const offsetY =  (currentRow < rows-1) ? (currentRow * m_map->getTileSize().y) : ((rows-1) * m_map->getTileSize().y);
 
         tson::Vector2i spacing = m_tileset->getMarginSpacingOffset({tileModX, currentRow});
-        m_drawingRect = { offsetX + spacing.x, offsetY + spacing.y, m_map->getTileSize().x, m_map->getTileSize().y };
+        m_drawingRect = { offsetX + spacing.x, offsetY + spacing.y, m_tileset->getTileSize().x, m_tileset->getTileSize().y };
     }
     else
         m_drawingRect = {0, 0, 0, 0};

--- a/tests/tests_projects_and_worlds.cpp
+++ b/tests/tests_projects_and_worlds.cpp
@@ -376,3 +376,25 @@ TEST_CASE("Parse Tiled v1.10 - classes used as property values",
     REQUIRE(tilesetClass->get<tson::TiledClass>("Transform").get<float>("X") == 20.);
     REQUIRE(tilesetClass->get<tson::TiledClass>("Transform").get<float>("Y") == 10.);
 }
+
+TEST_CASE("Parse Tiled v1.10 - tile DrawingRect is respected when different from the map tile grid",
+          "[project][map][tileset][tile]")
+{
+    fs::path pathToProject = GetPathWithBase(fs::path("test-maps/project-v1.10/test.tiled-project"));
+    REQUIRE(fs::exists(pathToProject));
+
+    tson::Project project{pathToProject};
+    tson::Tileson tileson{&project};
+
+    fs::path pathToMap = GetPathWithBase(fs::path("test-maps/project-v1.10/maps/map1.json"));
+    REQUIRE(fs::exists(pathToMap));
+
+    std::unique_ptr<tson::Map> map = tileson.parse(pathToMap);
+    REQUIRE(map != nullptr);
+    REQUIRE(map->getTileSize() == tson::Vector2<int>(32, 32));
+
+    tson::Tileset *tileset = map->getTileset("tileset1");
+    REQUIRE(tileset != nullptr);
+    REQUIRE(tileset->getTileSize() == tson::Vector2<int>(16, 16));
+    REQUIRE(tileset->getTile(1)->getDrawingRect() == tson::Rect(0, 0, 16, 16));
+}

--- a/tileson.hpp
+++ b/tileson.hpp
@@ -8668,7 +8668,7 @@ void tson::Tile::performDataCalculations()
 		int const offsetY =  (currentRow < rows-1) ? (currentRow * m_map->getTileSize().y) : ((rows-1) * m_map->getTileSize().y);
 
 		tson::Vector2i spacing = m_tileset->getMarginSpacingOffset({tileModX, currentRow});
-		m_drawingRect = { offsetX + spacing.x, offsetY + spacing.y, m_map->getTileSize().x, m_map->getTileSize().y };
+		m_drawingRect = { offsetX + spacing.x, offsetY + spacing.y, m_tileset->getTileSize().x, m_tileset->getTileSize().y };
 	}
 	else
 		m_drawingRect = {0, 0, 0, 0};

--- a/tileson_min.hpp
+++ b/tileson_min.hpp
@@ -7684,7 +7684,7 @@ void tson::Tile::performDataCalculations()
 		int const offsetY =  (currentRow < rows-1) ? (currentRow * m_map->getTileSize().y) : ((rows-1) * m_map->getTileSize().y);
 
 		tson::Vector2i spacing = m_tileset->getMarginSpacingOffset({tileModX, currentRow});
-		m_drawingRect = { offsetX + spacing.x, offsetY + spacing.y, m_map->getTileSize().x, m_map->getTileSize().y };
+		m_drawingRect = { offsetX + spacing.x, offsetY + spacing.y, m_tileset->getTileSize().x, m_tileset->getTileSize().y };
 	}
 	else
 		m_drawingRect = {0, 0, 0, 0};


### PR DESCRIPTION
This is an issue when the tile size doesn't perfectly match the map grid size which is a supported use case.

Fixes #108