### PR TITLE
Fix 90 and 270 degree rotations

### DIFF
--- a/examples/sfml/SfmlDemoManager.h
+++ b/examples/sfml/SfmlDemoManager.h
@@ -54,6 +54,8 @@ class SfmlDemoManager
 
         sf::Vector2f getTileOffset(int tileId, tson::Map *map, tson::Tileset* tileset);
 
+
+        const sf::Texture* getTexture(const std::string& image);
         sf::Sprite * storeAndLoadImage(const std::string &image, const sf::Vector2f &position);
         fs::path getTilesetImagePath(const tson::Tileset &tileset);
         void updateAnimations();


### PR DESCRIPTION
Address issue #115

The class method `SfmlDemoManager::drawTileLayer` is updated to draw the tiles correctly (referenced `CellRenderer::render` from the Tiled map [source](https://github.com/mapeditor/tiled) for inspiration on the fix).

The demo maps render correctly.